### PR TITLE
Skipping promise validation when skipRemaining method was called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `LightService` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [1.0.4] - 2019-03-27
+
+### Changed
+- Promise validation is now skipped if one of the actions called the `skipRemaining` method
+
 ## [1.0.3] - 2019-03-18
 
 ### Added

--- a/src/PostProcessor.php
+++ b/src/PostProcessor.php
@@ -17,8 +17,7 @@ class PostProcessor
     public static function validate(Organizer $organizer, Action $action)
     {
         $instance = new self($organizer, $action);
-        $context = $action->context;
-        if ($context[Organizer::SKIP_REMAINING] ?? false) {
+        if ($action->context[Organizer::SKIP_REMAINING] ?? false) {
             return;
         }
         $instance->checkPromises();

--- a/src/PostProcessor.php
+++ b/src/PostProcessor.php
@@ -17,6 +17,10 @@ class PostProcessor
     public static function validate(Organizer $organizer, Action $action)
     {
         $instance = new self($organizer, $action);
+        $context = $action->context;
+        if ($context[Organizer::SKIP_REMAINING] ?? false) {
+            return;
+        }
         $instance->checkPromises();
     }
 

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -36,6 +36,7 @@ class ActionTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteReturnsValidContext()
     {
-        $this->assertEquals(self::$action->execute([]), ['bar' => 1]);
+        self::$action->execute([]);
+        $this->assertEquals(self::$action->context, ['bar' => 1]);
     }
 }

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -36,7 +36,6 @@ class ActionTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteReturnsValidContext()
     {
-        self::$action->execute([]);
-        $this->assertEquals(self::$action->context, ['bar' => 1]);
+        $this->assertEquals(self::$action->execute([]), ['bar' => 1]);
     }
 }

--- a/tests/InvalidAction.php
+++ b/tests/InvalidAction.php
@@ -7,8 +7,7 @@ namespace crojasaragonez\LightService;
 class InvalidAction extends Action
 {
     public $promises = ['bar'];
-    public function execute(): ?array
+    public function execute()
     {
-        return $this->context;
     }
 }

--- a/tests/OrganizerTest.php
+++ b/tests/OrganizerTest.php
@@ -51,6 +51,14 @@ class OrganizerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that organizer skips promise validation when skipRemaining was called
+     */
+    public function testReduceWithSkipRemainingBrokenPromises()
+    {
+        $this->assertEquals(self::$organizer->reduce([SkipInvalidAction::class]), []);
+    }
+
+    /**
      * Test that organizer skips actions once the flag skip_remaining is set to true
      */
     public function testThatOrganizerSkipsActionsWhenFlagSkipRemainingIsTrue()

--- a/tests/SkipAction.php
+++ b/tests/SkipAction.php
@@ -6,9 +6,8 @@ namespace crojasaragonez\LightService;
 
 class SkipAction extends Action
 {
-    public function execute(): ?array
+    public function execute()
     {
         $this->skipRemaining();
-        return $this->context;
     }
 }

--- a/tests/SkipInvalidAction.php
+++ b/tests/SkipInvalidAction.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace crojasaragonez\LightService;
 
-class ActionWithReservedKey extends Action
+class SkipInvalidAction extends Action
 {
-    public $promises = ['skip_remaining'];
+    public $promises = ['bar'];
     public function execute()
     {
+        $this->skipRemaining();
     }
 }

--- a/tests/ValidAction.php
+++ b/tests/ValidAction.php
@@ -11,5 +11,6 @@ class ValidAction extends Action
     public function execute()
     {
         $this->context['bar'] = 1;
+        return $this->context;
     }
 }

--- a/tests/ValidAction.php
+++ b/tests/ValidAction.php
@@ -8,9 +8,8 @@ class ValidAction extends Action
 {
     public $expects  = ['foo'];
     public $promises = ['bar'];
-    public function execute(): ?array
+    public function execute()
     {
         $this->context['bar'] = 1;
-        return $this->context;
     }
 }


### PR DESCRIPTION
## Skipping promise validation when skipRemaining method was called

## Motivation and context

Promises should not be validated if the action called the `skipRemaining` method.

## How has this been tested?

New scenarios were covered with unit tests

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

