### PR TITLE
feat: add progress callback support to Organizer::reduce()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `LightService` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [2.1.0] - 2025-12-30
+
+### Added
+- Progress callback support in `Organizer::reduce()` method
+- Optional `$onProgress` callback parameter to track action execution progress
+- Callback receives: `$current` (processed count), `$total` (total actions), `$action` (class name), `$skipped` (boolean)
+
 ## [2.0.0] - 2025-12-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ $result = $organizer->reduce([
 print_r($result);
 ```
 
+### Progress Tracking
+
+You can track the progress of action execution by passing a callback to `reduce()`:
+
+``` php
+$organizer = new Organizer(['url' => 'https://example.com/image.png']);
+$result = $organizer->reduce([
+  CreateTmpFile::class,
+  Download::class,
+  ZipFile::class
+], function(int $current, int $total, string $action, bool $skipped) {
+    echo "[{$current}/{$total}] {$action}" . ($skipped ? ' (skipped)' : '') . "\n";
+});
+```
+
+The callback receives:
+- `$current` - Number of actions processed so far (1-indexed)
+- `$total` - Total number of actions
+- `$action` - The class name of the action just processed
+- `$skipped` - Whether the action was skipped (due to `skipRemaining()`)
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     },
     "config": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding an optional **onProgress** callback so users can watch the progress in Organizer

## Motivation and context

Let's say that you want to include a progress bar in the application. with the new optional callback, you have access to progress information.

## How has this been tested?

Unit testing

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
